### PR TITLE
DomaのGitHubリポジトリへのリンクを修正しました。

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -209,7 +209,7 @@ extlinks = {
   'macchinetta-cloud-guideline-doc': ('https://macchinetta.github.io/cloud-guideline/' + '1.0.1.RELEASE' + '/ja/%s', None),
   'macchinetta-batch-guideline-doc': ('https://macchinetta.github.io/batch-guideline/' + '2.0.1.RELEASE' + '/ja/%s', None),
   'thymeleaf-tutorials-doc': ('https://www.thymeleaf.org/doc/tutorials/' + '3.0' + '/%s', None),
-  'doma-spring-boot-source': ('https://github.com/domaframework/doma-spring-boot/blob/' + '1.1.x' + '/%s', None),
+  'doma-spring-boot-source': ('https://github.com/domaframework/doma-spring-boot/blob/' + '1.1.1' + '/%s', None),
   'doma-doc': ('https://doma.readthedocs.io/ja/' + '2.19.2' + '/%s', None),
   'doma-java-doc': ('https://static.javadoc.io/org.seasar.doma/doma/' + '2.19.2' + '/%s', None),
   'doma-gen-doc': ('https://doma-gen.readthedocs.io/ja/' + '2.19.2' + '/%s', None),


### PR DESCRIPTION
もともと`1.1.x`ブランチを指していましたがdoma-spring-boot側で該当ブランチが削除されたため`1.1.1`タグを指すようにしました。