### PR TITLE
SpotBugsで違反になる箇所を修正

### DIFF
--- a/samples/aws/s3/src/main/java/keel/aws/s3/AwsS3DownloadService.java
+++ b/samples/aws/s3/src/main/java/keel/aws/s3/AwsS3DownloadService.java
@@ -1,15 +1,17 @@
 package keel.aws.s3;
 
-import io.awspring.cloud.s3.S3Template;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import io.awspring.cloud.s3.S3Template;
 
 // download-start
 @Service
@@ -36,7 +38,7 @@ public class AwsS3DownloadService {
         }
 
         try (InputStream inputStream = s3Template.download(
-                properties.getBucketName(), path.getFileName().toString()).getInputStream()) {
+                properties.getBucketName(), Objects.toString(path.getFileName())).getInputStream()) {
             Files.copy(inputStream, downloadPath);
             logger.info("ファイルの保存に成功しました。");
         } catch (IOException e) {

--- a/samples/aws/s3/src/main/java/keel/aws/s3/AwsS3DownloadService.java
+++ b/samples/aws/s3/src/main/java/keel/aws/s3/AwsS3DownloadService.java
@@ -45,9 +45,5 @@ public class AwsS3DownloadService {
             throw new UncheckedIOException("S3からのファイルダウンロードに失敗しました。", e);
         }
     }
-
-    private String createObjectLocation(Path path) {
-        return "s3://" + properties.getBucketName() + "/upload/" + path.getFileName();
-    }
 }
 // download-end

--- a/samples/aws/s3/src/main/java/keel/aws/s3/AwsS3UploadService.java
+++ b/samples/aws/s3/src/main/java/keel/aws/s3/AwsS3UploadService.java
@@ -5,11 +5,13 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 
-import io.awspring.cloud.s3.S3Template;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+
+import io.awspring.cloud.s3.S3Template;
 
 // upload-start
 @Service
@@ -29,8 +31,8 @@ public class AwsS3UploadService {
     public void uploadFile(Path path) {
         logger.info("{}をS3にアップロードします。", path.getFileName());
 
-        try (InputStream inputStream = Files.newInputStream(path)){
-            s3Template.upload(properties.getBucketName(), path.getFileName().toString(), inputStream);
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            s3Template.upload(properties.getBucketName(), Objects.toString(path.getFileName()), inputStream);
             logger.info("ファイルのアップロードに成功しました。");
         } catch (IOException e) {
             throw new UncheckedIOException("S3へのファイルアップロードに失敗しました。", e);

--- a/samples/batch/multiple-jobs-batch/src/test/java/keel/batch/multiple/MultipleJobsBatchApplicationTest.java
+++ b/samples/batch/multiple-jobs-batch/src/test/java/keel/batch/multiple/MultipleJobsBatchApplicationTest.java
@@ -1,5 +1,7 @@
 package keel.batch.multiple;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
@@ -9,10 +11,7 @@ import org.springframework.batch.test.context.SpringBatchTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBatchTest
 @SpringBootTest(classes = MultipleJobsBatchApplication.class)
@@ -21,9 +20,6 @@ public class MultipleJobsBatchApplicationTest {
 
     @Autowired
     private JobLauncherTestUtils jobLauncherTestUtils;
-
-    @Autowired
-    private JdbcTemplate template;
 
     @Autowired
     @Qualifier("job1")

--- a/samples/web/template-engine-thymeleaf/src/test/java/keel/thymeleaf/DefaultValueSampleControllerTest.java
+++ b/samples/web/template-engine-thymeleaf/src/test/java/keel/thymeleaf/DefaultValueSampleControllerTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 @WebMvcTest(DefaultValueSampleController.class)
 public class DefaultValueSampleControllerTest {

--- a/samples/web/tomcat-access-log/src/main/java/keel/AccessLogApp.java
+++ b/samples/web/tomcat-access-log/src/main/java/keel/AccessLogApp.java
@@ -2,11 +2,6 @@ package keel;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication
 public class AccessLogApp {


### PR DESCRIPTION
## 概要

S3のサンプルがSpotBugsで違反になっていました。
`Path.getFileName`が`null`を返す可能性があるからというもので、`Objects.toString`を適用することで回避しました。

ついでに未使用の`import`やメソッド、フィールドの削除も行いました。

## レビュー依頼前のチェックリスト

- [x] 作業時間を記録していること
- [x] セルフレビュー済みであること
- [x] PRに適切なtarget branchを設定済みであること

ソースコード特有の項目

- [] 理解しづらいコードはコメントで補足説明済みであること
- [x] `./mvn clean verify`を実行して結果が`BUILD SUCCESS`であること

## 動作確認方法

- [x] `aws/s3`で`mvn spotbugs:check`を実行して違反が0件であること

## レビューアに確認して欲しいポイント

## レビューアへの申し送り事項

(もしあれば書く)

## その他、気になること

(もしあれば書く)

---

## レビュー後、マージ前のチェックリスト（レビューア用のチェックリスト）

- [x] レビュー時間を記録していること
- [x] PRに適切なtarget branchを設定済みであること

---

| 作業分類             |時間(h)|
|------------------|---|
| 実装・執筆            |0.5|
| レビュー |0|
